### PR TITLE
Set opus bitrate within default max bandwidth

### DIFF
--- a/gumble/client.go
+++ b/gumble/client.go
@@ -87,6 +87,8 @@ func (c *Client) Connect() error {
 		return err
 	}
 	encoder.SetVbr(false)
+	/* TODO: set this to the server's max bitrate */
+	encoder.SetBitrate(40000)
 	c.audioSequence = 0
 	c.audioTarget = nil
 


### PR DESCRIPTION
The Opus bitrate was set to 40000 in a previous version of piepan: https://github.com/layeh/piepan/blob/d4033fcf68c6fe9b708f16d6bb025c1bf28bdbd2/src/piepan.c#L358 The bitrate is no longer set, so Opus uses 72000. This is larger than Murmur's max bandwidth default setting, causing audio skipping.

As your TODO indicates, the max bitrate should be calculated based off the server's max bitrate. See https://github.com/mumble-voip/mumble/blob/acf73f58153c6d53182087302038dd0cc639d9d1/src/mumble/AudioConfigDialog.cpp#L260
