### PR TITLE
Add volume variable to Stream

### DIFF
--- a/gumble_ffmpeg/gumble_ffmpeg.go
+++ b/gumble_ffmpeg/gumble_ffmpeg.go
@@ -3,6 +3,7 @@ package gumble_ffmpeg
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"strconv"
@@ -18,11 +19,13 @@ type Stream struct {
 	cmd        *exec.Cmd
 	pipe       io.ReadCloser
 	sourceStop chan bool
+	volume     float32
 }
 
 func New(client *gumble.Client) (*Stream, error) {
 	stream := &Stream{
 		client: client,
+		volume: 1.0,
 	}
 	return stream, nil
 }
@@ -31,7 +34,7 @@ func (s *Stream) Play(file string) error {
 	if s.sourceStop != nil {
 		return errors.New("already playing")
 	}
-	s.cmd = exec.Command("ffmpeg", "-i", file, "-ac", "1", "-ar", strconv.Itoa(gumble.AudioSampleRate), "-f", "s16le", "-")
+	s.cmd = exec.Command("ffmpeg", "-i", file, "-ac", "1", "-ar", strconv.Itoa(gumble.AudioSampleRate), "-af", fmt.Sprintf("volume=%f", s.volume), "-f", "s16le", "-")
 	if pipe, err := s.cmd.StdoutPipe(); err != nil {
 		s.cmd = nil
 		return nil


### PR DESCRIPTION
Hi there,

I noticed that there wasn't a way to specify the volume of a Stream within `gumble`. I went ahead and made this change and it seems to work fine.

Hope this helps!
