### PR TITLE
Fixing issue where after StopSource is called StartSource stops working

### DIFF
--- a/gumbleopenal/stream.go
+++ b/gumbleopenal/stream.go
@@ -74,6 +74,14 @@ func (s *Stream) StopSource() error {
 	close(s.sourceStop)
 	s.sourceStop = nil
 	s.deviceSource.CaptureStop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	s.deviceSource.CaptureCloseDevice()
+	s.deviceSource = nil
+
+	s.deviceSource = openal.CaptureOpenDevice("", gumble.AudioSampleRate, openal.FormatMono16, uint32(s.sourceFrameSize))
+
 	return nil
 }
 


### PR DESCRIPTION
I tried to track down the exact issue, but it seems to be within OpenAL itself.  This seems a little hacky, but works, and is cleanly inserted.
