### PR TITLE
Add client config flag to explicitly signal Opus support

### DIFF
--- a/gumble/client.go
+++ b/gumble/client.go
@@ -115,6 +115,9 @@ func DialWithDialer(dialer *net.Dialer, addr string, config *Config, tlsConfig *
 
 	go client.readRoutine()
 
+	// If Opus support was not explicitly enabled, set Opus flag
+	// based on the presence of the Opus audio codec.
+	opus := client.Config.Opus || getAudioCodec(audioCodecIDOpus) != nil
 	// Initial packets
 	versionPacket := MumbleProto.Version{
 		Version:   proto.Uint32(ClientVersion),
@@ -125,7 +128,7 @@ func DialWithDialer(dialer *net.Dialer, addr string, config *Config, tlsConfig *
 	authenticationPacket := MumbleProto.Authenticate{
 		Username: &client.Config.Username,
 		Password: &client.Config.Password,
-		Opus:     proto.Bool(getAudioCodec(audioCodecIDOpus) != nil),
+		Opus:     proto.Bool(opus),
 		Tokens:   client.Config.Tokens,
 	}
 	client.Conn.WriteProto(&versionPacket)

--- a/gumble/config.go
+++ b/gumble/config.go
@@ -26,6 +26,11 @@ type Config struct {
 	// The event listeners used when client events are triggered.
 	Listeners      Listeners
 	AudioListeners AudioListeners
+
+	// If true, explicitly signals presence of Opus support.  If
+	// false, this is determined automatically by the presence of
+	// an Opus codec implementation.
+	Opus bool
 }
 
 // NewConfig returns a new Config struct with default values set.

--- a/gumble/doc.go
+++ b/gumble/doc.go
@@ -36,6 +36,12 @@
 //
 //  opusthreshold=0
 //
+// If your client is not processing audio at all, you can still claim
+// to support Opus so that the Mumble server won't force usage of the
+// legacy CELT codec:
+//
+//        config.Opus = true
+//
 // Thread safety
 //
 // As a general rule, a Client everything that is associated with it


### PR DESCRIPTION
Add client config flag to explicitly signal Opus support even when the Opus audio codec is not loaded.

This is useful if a client based on gumble doesn't actually process audio at all. By signalling Opus support anyway, this doesn't force everyone back to CELT if a gumble client is the only client not claiming Opus support. We can't be sure that the server admin has actually set `opusthreshold = 0`, so this is a pure-client way to prevent a CELT fallback.